### PR TITLE
네이버 API를 활용한 도서 검색 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/suggestion/book/domain/book/controller/BookSearchController.java
+++ b/src/main/java/com/suggestion/book/domain/book/controller/BookSearchController.java
@@ -1,0 +1,20 @@
+package com.suggestion.book.domain.book.controller;
+
+import com.suggestion.book.domain.book.dto.BookListResponseDto;
+import com.suggestion.book.domain.book.service.BookSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@RestController
+public class BookSearchController {
+    private final BookSearchService bookSearchService;
+
+    @GetMapping(path = "/search/book")
+    public Mono<BookListResponseDto> getBookList(@RequestParam String title, @RequestParam int start){
+        return bookSearchService.searchByBookTitle(title,start);
+    }
+}

--- a/src/main/java/com/suggestion/book/domain/book/dto/BookDto.java
+++ b/src/main/java/com/suggestion/book/domain/book/dto/BookDto.java
@@ -1,0 +1,18 @@
+package com.suggestion.book.domain.book.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BookDto {
+    public String title;
+    public String link;
+    public String image;
+    public String author;
+    public String discount;
+    public String publisher;
+    public String pubdate;
+    public String isbn;
+    public String description;
+}

--- a/src/main/java/com/suggestion/book/domain/book/dto/BookListResponseDto.java
+++ b/src/main/java/com/suggestion/book/domain/book/dto/BookListResponseDto.java
@@ -1,0 +1,15 @@
+package com.suggestion.book.domain.book.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class BookListResponseDto {
+    public int total;
+    public int start;
+    public int display;
+    public List<BookDto> items;
+}

--- a/src/main/java/com/suggestion/book/domain/book/service/BookSearchService.java
+++ b/src/main/java/com/suggestion/book/domain/book/service/BookSearchService.java
@@ -1,0 +1,27 @@
+package com.suggestion.book.domain.book.service;
+
+import com.suggestion.book.domain.book.dto.BookListResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class BookSearchService {
+    private final WebClient webClientApi;
+
+    public static final String URI = "/search/book_adv.json";
+
+    public Mono<BookListResponseDto> searchByBookTitle(String title, int start) {
+        return webClientApi
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(URI)
+                        .queryParam("d_titl", title)
+                        .queryParam("start", start)
+                        .build())
+                .retrieve()
+                .bodyToMono(BookListResponseDto.class);
+    }
+}

--- a/src/main/java/com/suggestion/book/domain/member/controller/MemberController.java
+++ b/src/main/java/com/suggestion/book/domain/member/controller/MemberController.java
@@ -15,7 +15,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping(path = "/member")
-    public ApiResponse getUser() {
+    public ApiResponse<?> getUser() {
         User principal = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         Member member = memberService.getMember(principal.getUsername());
 

--- a/src/main/java/com/suggestion/book/global/common/ApiResponse.java
+++ b/src/main/java/com/suggestion/book/global/common/ApiResponse.java
@@ -27,22 +27,22 @@ public class ApiResponse<T> {
         Map<String, T> map = new HashMap<>();
         map.put(name, body);
 
-        return new ApiResponse(new ApiResponseHeader(SUCCESS, SUCCESS_MESSAGE), map);
+        return new ApiResponse<>(new ApiResponseHeader(SUCCESS, SUCCESS_MESSAGE), map);
     }
 
     public static <T> ApiResponse<T> fail() {
-        return new ApiResponse(new ApiResponseHeader(FAILED, FAILED_MESSAGE), null);
+        return new ApiResponse<>(new ApiResponseHeader(FAILED, FAILED_MESSAGE), null);
     }
 
     public static <T> ApiResponse<T> invalidAccessToken() {
-        return new ApiResponse(new ApiResponseHeader(FAILED, INVALID_ACCESS_TOKEN), null);
+        return new ApiResponse<>(new ApiResponseHeader(FAILED, INVALID_ACCESS_TOKEN), null);
     }
 
     public static <T> ApiResponse<T> invalidRefreshToken() {
-        return new ApiResponse(new ApiResponseHeader(FAILED, INVALID_REFRESH_TOKEN), null);
+        return new ApiResponse<>(new ApiResponseHeader(FAILED, INVALID_REFRESH_TOKEN), null);
     }
 
     public static <T> ApiResponse<T> notExpiredTokenYet() {
-        return new ApiResponse(new ApiResponseHeader(FAILED, NOT_EXPIRED_TOKEN_YET), null);
+        return new ApiResponse<>(new ApiResponseHeader(FAILED, NOT_EXPIRED_TOKEN_YET), null);
     }
 }

--- a/src/main/java/com/suggestion/book/global/config/SecurityConfig.java
+++ b/src/main/java/com/suggestion/book/global/config/SecurityConfig.java
@@ -59,6 +59,7 @@ public class SecurityConfig{
                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                 .antMatchers("/api/**").hasAnyAuthority(RoleType.USER.getCode())
                 .antMatchers("/api/**/admin/**").hasAnyAuthority(RoleType.ADMIN.getCode())
+                .antMatchers("/search/*").permitAll()
                 .anyRequest().authenticated() //모든 사용자는 인증이 되어야 한다.
                 .and()
                 .oauth2Login()

--- a/src/main/java/com/suggestion/book/global/config/WebClientConfig.java
+++ b/src/main/java/com/suggestion/book/global/config/WebClientConfig.java
@@ -1,0 +1,24 @@
+package com.suggestion.book.global.config;
+
+import com.suggestion.book.global.config.properties.ApiProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebClientConfig {
+
+    private final ApiProperties apiProperties;
+
+    @Bean
+    public WebClient WebClientApi(WebClient.Builder webClientBuilder) {
+        return webClientBuilder
+                .clone()
+                .baseUrl(apiProperties.getNaver().getUrl())
+                .defaultHeader("X-Naver-Client-Id", apiProperties.getNaver().getNaverClientId())
+                .defaultHeader("X-Naver-Client-Secret", apiProperties.getNaver().getNaverClientSecret())
+                .build();
+    }
+}

--- a/src/main/java/com/suggestion/book/global/config/properties/ApiProperties.java
+++ b/src/main/java/com/suggestion/book/global/config/properties/ApiProperties.java
@@ -1,0 +1,22 @@
+package com.suggestion.book.global.config.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@Getter
+@RequiredArgsConstructor
+@ConstructorBinding
+@ConfigurationProperties(prefix = "api")
+public class ApiProperties {
+    private final Naver naver;
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class Naver {
+        private final String url;
+        private final String naverClientId;
+        private final String naverClientSecret;
+    }
+}


### PR DESCRIPTION
### 이슈

- #6 

### 주요 변경 사항
1. WebClient를 사용해 비동기 통신으로 도서 검색 기능을 구현 하였습니다.
2. 도서 검색 API로는 네이버 도서 검색 API를 사용하였습니다.
3. 페이징 처리를 추후에 구현하여야 합니다. 

<br>

#### 참고
[WebClient 공식문서](https://docs.spring.io/spring-framework/docs/5.3.10/reference/html/web-reactive.html#webflux-client)
[Spring Boot WebClient Example](https://www.techgeeknext.com/spring-boot/webflux/spring-boot-webclient-example)

closes #6 


