### PR TITLE
알라딘 API를 활용한 베스트셀러 조회 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	runtimeOnly "io.netty:netty-resolver-dns-native-macos:4.1.76.Final:osx-aarch_64"// 배포할때는 필요 없음
 }
 
 tasks.named('test') {

--- a/src/main/java/com/suggestion/book/domain/book/service/BookSearchService.java
+++ b/src/main/java/com/suggestion/book/domain/book/service/BookSearchService.java
@@ -9,12 +9,13 @@ import reactor.core.publisher.Mono;
 @Service
 @RequiredArgsConstructor
 public class BookSearchService {
-    private final WebClient webClientApi;
+
+    private final WebClient naverWebClientApi;
 
     public static final String URI = "/search/book_adv.json";
 
     public Mono<BookListResponseDto> searchByBookTitle(String title, int start) {
-        return webClientApi
+        return naverWebClientApi
                 .get()
                 .uri(uriBuilder -> uriBuilder
                         .path(URI)

--- a/src/main/java/com/suggestion/book/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/suggestion/book/domain/recommendation/controller/RecommendationController.java
@@ -1,0 +1,19 @@
+package com.suggestion.book.domain.recommendation.controller;
+
+import com.suggestion.book.domain.recommendation.dto.BestSellerListResponseDto;
+import com.suggestion.book.domain.recommendation.service.RecommendationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@RestController
+public class RecommendationController {
+    private final RecommendationService recommendationService;
+
+    @GetMapping(path = "/recommendation/bestSeller")
+    public Mono<BestSellerListResponseDto> getBestSellerList() {
+        return recommendationService.getBestSeller();
+    }
+}

--- a/src/main/java/com/suggestion/book/domain/recommendation/dto/BestSellerDto.java
+++ b/src/main/java/com/suggestion/book/domain/recommendation/dto/BestSellerDto.java
@@ -1,0 +1,18 @@
+package com.suggestion.book.domain.recommendation.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BestSellerDto {
+    public String title;
+    public String link;
+    public String cover;
+    public String author;
+    public String publisher;
+    public String isbn13;
+    public String description;
+    public String pubDate;
+    public int bestRank;
+}

--- a/src/main/java/com/suggestion/book/domain/recommendation/dto/BestSellerListResponseDto.java
+++ b/src/main/java/com/suggestion/book/domain/recommendation/dto/BestSellerListResponseDto.java
@@ -1,0 +1,15 @@
+package com.suggestion.book.domain.recommendation.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class BestSellerListResponseDto {
+    public String title;
+    public String itemsPerPage;
+    public String searchCategoryName;
+    public List<BestSellerDto> item;
+}

--- a/src/main/java/com/suggestion/book/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/suggestion/book/domain/recommendation/service/RecommendationService.java
@@ -1,0 +1,31 @@
+package com.suggestion.book.domain.recommendation.service;
+
+import com.suggestion.book.domain.recommendation.dto.BestSellerListResponseDto;
+import com.suggestion.book.global.config.properties.ApiProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendationService {
+    private final WebClient aladinWebClientApi;
+    private final ApiProperties apiProperties;
+    private static final String URI = "/ItemList.aspx";
+
+    public Mono<BestSellerListResponseDto> getBestSeller() {
+        return aladinWebClientApi
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(URI)
+                        .queryParam("ttbkey", apiProperties.getAladin().getTtbKey())
+                        .queryParam("QueryType", "Bestseller")
+                        .queryParam("SearchTarget","Book")
+                        .queryParam("Version","20131101")
+                        .queryParam("output","js")
+                        .build())
+                .retrieve()
+                .bodyToMono(BestSellerListResponseDto.class);
+    }
+}

--- a/src/main/java/com/suggestion/book/global/config/SecurityConfig.java
+++ b/src/main/java/com/suggestion/book/global/config/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig{
                 .antMatchers("/api/**").hasAnyAuthority(RoleType.USER.getCode())
                 .antMatchers("/api/**/admin/**").hasAnyAuthority(RoleType.ADMIN.getCode())
                 .antMatchers("/search/*").permitAll()
+                .antMatchers("/recommendation/*").permitAll()
                 .anyRequest().authenticated() //모든 사용자는 인증이 되어야 한다.
                 .and()
                 .oauth2Login()

--- a/src/main/java/com/suggestion/book/global/config/WebClientConfig.java
+++ b/src/main/java/com/suggestion/book/global/config/WebClientConfig.java
@@ -13,12 +13,20 @@ public class WebClientConfig {
     private final ApiProperties apiProperties;
 
     @Bean
-    public WebClient WebClientApi(WebClient.Builder webClientBuilder) {
+    public WebClient naverWebClientApi(WebClient.Builder webClientBuilder) {
         return webClientBuilder
                 .clone()
-                .baseUrl(apiProperties.getNaver().getUrl())
+                .baseUrl(apiProperties.getNaver().getUri())
                 .defaultHeader("X-Naver-Client-Id", apiProperties.getNaver().getNaverClientId())
                 .defaultHeader("X-Naver-Client-Secret", apiProperties.getNaver().getNaverClientSecret())
+                .build();
+    }
+
+    @Bean
+    public WebClient aladinWebClientApi(WebClient.Builder webClientBuilder) {
+        return webClientBuilder
+                .clone()
+                .baseUrl(apiProperties.getAladin().getUri())
                 .build();
     }
 }

--- a/src/main/java/com/suggestion/book/global/config/properties/ApiProperties.java
+++ b/src/main/java/com/suggestion/book/global/config/properties/ApiProperties.java
@@ -11,12 +11,20 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 @ConfigurationProperties(prefix = "api")
 public class ApiProperties {
     private final Naver naver;
+    private final Aladin aladin;
 
     @Getter
     @RequiredArgsConstructor
     public static class Naver {
-        private final String url;
+        private final String uri;
         private final String naverClientId;
         private final String naverClientSecret;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class Aladin {
+        private final String uri;
+        private final String ttbKey;
     }
 }


### PR DESCRIPTION
### 이슈

- #8 

### 주요 변경 사항
1.  알라딘 WebClient Been을 추가하였습니다.
2. 알라딘 API 를 통해 금주 베스트셀러 도서 10권이 조회가 가능합니다.

<br>

#### 참고
[알라딘 Open API 매뉴얼](https://docs.google.com/document/d/1mX-WxuoGs8Hy-QalhHcvuV17n50uGI2Sg_GHofgiePE/edit)

closes #8 



