### PR TITLE
장르별 도서리스트 응답 API 구현

### DIFF
--- a/src/main/java/com/suggestion/book/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/suggestion/book/domain/recommendation/controller/RecommendationController.java
@@ -4,16 +4,23 @@ import com.suggestion.book.domain.recommendation.dto.BestSellerListResponseDto;
 import com.suggestion.book.domain.recommendation.service.RecommendationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
 @RequiredArgsConstructor
 @RestController
 public class RecommendationController {
+
     private final RecommendationService recommendationService;
 
     @GetMapping(path = "/recommendation/bestSeller")
     public Mono<BestSellerListResponseDto> getBestSellerList() {
         return recommendationService.getBestSeller();
+    }
+
+    @GetMapping(path = "/recommendation/genre")
+    public Mono<BestSellerListResponseDto> getByGenreBookList(@RequestParam int category) {
+        return recommendationService.getByGenre(category);
     }
 }

--- a/src/main/java/com/suggestion/book/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/suggestion/book/domain/recommendation/service/RecommendationService.java
@@ -10,6 +10,7 @@ import reactor.core.publisher.Mono;
 @Service
 @RequiredArgsConstructor
 public class RecommendationService {
+
     private final WebClient aladinWebClientApi;
     private final ApiProperties apiProperties;
     private static final String URI = "/ItemList.aspx";
@@ -22,7 +23,25 @@ public class RecommendationService {
                         .queryParam("ttbkey", apiProperties.getAladin().getTtbKey())
                         .queryParam("QueryType", "Bestseller")
                         .queryParam("SearchTarget","Book")
-                        .queryParam("Version","20131101")
+                        .queryParam("Version",20131101)
+                        .queryParam("Cover","Big")
+                        .queryParam("output","js")
+                        .build())
+                .retrieve()
+                .bodyToMono(BestSellerListResponseDto.class);
+    }
+
+    public Mono<BestSellerListResponseDto> getByGenre(int category) {
+        return aladinWebClientApi
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(URI)
+                        .queryParam("ttbkey", apiProperties.getAladin().getTtbKey())
+                        .queryParam("QueryType", "Bestseller")
+                        .queryParam("SearchTarget","Book")
+                        .queryParam("Version",20131101)
+                        .queryParam("CategoryId",category)
+                        .queryParam("Cover","Big")
                         .queryParam("output","js")
                         .build())
                 .retrieve()


### PR DESCRIPTION
### 이슈

- #10 

### 주요 변경 사항
1. 알라딘 API를 활용해 장르별로 베스트셀러 도서 10권을 응답합니다.
2. 장르는 정수형 고유번호로 입력 해주세요.

<br>

#### 참고
[알라딘 Open API 매뉴얼](https://docs.google.com/document/d/1mX-WxuoGs8Hy-QalhHcvuV17n50uGI2Sg_GHofgiePE/edit)

closes #10 

