### PR TITLE
도서관에 소장중인 도서 조회 기능 구현

### DIFF
--- a/src/main/java/com/suggestion/book/domain/book/controller/LibraryController.java
+++ b/src/main/java/com/suggestion/book/domain/book/controller/LibraryController.java
@@ -1,0 +1,21 @@
+package com.suggestion.book.domain.book.controller;
+
+import com.suggestion.book.domain.book.dto.LibraryListResponseDto;
+import com.suggestion.book.domain.book.service.LibraryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@RestController
+public class LibraryController {
+    private final LibraryService libraryService;
+
+    @GetMapping(path = "/search/book/{isbn}/library/region/{region}")
+    public Mono<LibraryListResponseDto> libraryWithBooks(@PathVariable(name = "isbn") String isbn,
+                                                         @PathVariable(name = "region") int region){
+        return libraryService.libraryWithBooks(isbn,region);
+    }
+}

--- a/src/main/java/com/suggestion/book/domain/book/dto/LibraryDto.java
+++ b/src/main/java/com/suggestion/book/domain/book/dto/LibraryDto.java
@@ -1,0 +1,27 @@
+package com.suggestion.book.domain.book.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.tomcat.jni.Library;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class LibraryDto {
+    public Library lib;
+
+    public static class Library{
+        public String libCode;
+        public String libName;
+        public String address;
+        public String tel;
+        public String fax;
+        public String latitude;
+        public String longitude;
+        public String homepage;
+        public String closed;
+        public String operatingTime;
+    }
+}
+

--- a/src/main/java/com/suggestion/book/domain/book/dto/LibraryListResponseDto.java
+++ b/src/main/java/com/suggestion/book/domain/book/dto/LibraryListResponseDto.java
@@ -1,0 +1,20 @@
+package com.suggestion.book.domain.book.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class LibraryListResponseDto {
+    public LibraryList response;
+
+    public static class LibraryList{
+        public String pageNo;
+        public String pageSize;
+        public String numFound;
+        public String resultNum;
+        public List<LibraryDto> libs;
+    }
+}

--- a/src/main/java/com/suggestion/book/domain/book/service/LibraryService.java
+++ b/src/main/java/com/suggestion/book/domain/book/service/LibraryService.java
@@ -1,0 +1,31 @@
+package com.suggestion.book.domain.book.service;
+
+import com.suggestion.book.domain.book.dto.LibraryListResponseDto;
+import com.suggestion.book.global.config.properties.ApiProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class LibraryService {
+    private final WebClient data4libraryWebClientApi;
+    private final ApiProperties apiProperties;
+    public static final String URI = "/libSrchByBook";
+
+    public Mono<LibraryListResponseDto> libraryWithBooks(String isbn, int region) {
+        return data4libraryWebClientApi
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(URI)
+                        .queryParam("authKey", apiProperties.getNaru().getAuthKey())
+                        .queryParam("isbn", isbn)
+                        .queryParam("region", region)
+                        .queryParam("pageSize", 20)
+                        .queryParam("format", "json")
+                        .build())
+                .retrieve()
+                .bodyToMono(LibraryListResponseDto.class);
+    }
+}

--- a/src/main/java/com/suggestion/book/global/config/SecurityConfig.java
+++ b/src/main/java/com/suggestion/book/global/config/SecurityConfig.java
@@ -59,9 +59,9 @@ public class SecurityConfig{
                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                 .antMatchers("/api/**").hasAnyAuthority(RoleType.USER.getCode())
                 .antMatchers("/api/**/admin/**").hasAnyAuthority(RoleType.ADMIN.getCode())
-                .antMatchers("/search/*").permitAll()
-                .antMatchers("/recommendation/*").permitAll()
-                .antMatchers("/reviews/*").permitAll()
+                .antMatchers("/search/**").permitAll()
+                .antMatchers("/recommendation/**").permitAll()
+                .antMatchers("/reviews/**").permitAll()
                 .anyRequest().authenticated() //모든 사용자는 인증이 되어야 한다.
                 .and()
                 .oauth2Login()

--- a/src/main/java/com/suggestion/book/global/config/WebClientConfig.java
+++ b/src/main/java/com/suggestion/book/global/config/WebClientConfig.java
@@ -12,6 +12,10 @@ public class WebClientConfig {
 
     private final ApiProperties apiProperties;
 
+
+    /**
+     * 네이버 WebClient
+     */
     @Bean
     public WebClient naverWebClientApi(WebClient.Builder webClientBuilder) {
         return webClientBuilder
@@ -22,11 +26,26 @@ public class WebClientConfig {
                 .build();
     }
 
+
+    /**
+     * 알라딘 WebClient
+     */
     @Bean
     public WebClient aladinWebClientApi(WebClient.Builder webClientBuilder) {
         return webClientBuilder
                 .clone()
                 .baseUrl(apiProperties.getAladin().getUri())
+                .build();
+    }
+
+    /**
+     * 도서관 정보 나루 WebClient
+     */
+    @Bean
+    public WebClient data4libraryWebClientApi(WebClient.Builder webClientBuilder) {
+        return webClientBuilder
+                .clone()
+                .baseUrl(apiProperties.getNaru().getUri())
                 .build();
     }
 }

--- a/src/main/java/com/suggestion/book/global/config/properties/ApiProperties.java
+++ b/src/main/java/com/suggestion/book/global/config/properties/ApiProperties.java
@@ -12,6 +12,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 public class ApiProperties {
     private final Naver naver;
     private final Aladin aladin;
+    private final Naru naru;
 
     @Getter
     @RequiredArgsConstructor
@@ -26,5 +27,12 @@ public class ApiProperties {
     public static class Aladin {
         private final String uri;
         private final String ttbKey;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class Naru {
+        private final String uri;
+        private final String authKey;
     }
 }


### PR DESCRIPTION
### 이슈

- #24 

### 주요 변경 사항
1. 도서관 정보나루 WebClient 빈을 생성하였습니다.
2. 이제 도서관 정보나루 API를 사용해 도서를 소장중인 도서관 조회가 가능합니다.


<br>

#### 참고
[도서관정보나루](https://www.data4library.kr/)

closes #24 


