### PR TITLE
비슷한 도서 추천 기능 구현

### DIFF
--- a/src/main/java/com/suggestion/book/domain/book/controller/BookController.java
+++ b/src/main/java/com/suggestion/book/domain/book/controller/BookController.java
@@ -1,0 +1,20 @@
+package com.suggestion.book.domain.book.controller;
+
+import com.suggestion.book.domain.book.dto.SimilarBookListResponseDto;
+import com.suggestion.book.domain.book.service.BookService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequiredArgsConstructor
+public class BookController {
+    private final BookService bookService;
+
+    @GetMapping(path = "/search/book/{isbn}/similar-book/{type}")
+    public Mono<SimilarBookListResponseDto> getSimilarBookList(@PathVariable() String isbn, @PathVariable() String type){
+        return bookService.getSimilarBookList(isbn, type);
+    }
+}

--- a/src/main/java/com/suggestion/book/domain/book/dto/SimilarBook.java
+++ b/src/main/java/com/suggestion/book/domain/book/dto/SimilarBook.java
@@ -1,0 +1,29 @@
+package com.suggestion.book.domain.book.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SimilarBook {
+    public Book book;
+    @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class Book{
+        public String no;
+        @JsonProperty("bookname")
+        public String bookName;
+        public String authors;
+        public String publisher;
+        public String publicationYear;
+        public String isbn13;
+        public String additionSymbol;
+        public String vol;
+        public String classNo;
+        public String classNm;
+        @JsonProperty("bookImageURL")
+        public String bookImageURL;
+    }
+}

--- a/src/main/java/com/suggestion/book/domain/book/dto/SimilarBookListResponseDto.java
+++ b/src/main/java/com/suggestion/book/domain/book/dto/SimilarBookListResponseDto.java
@@ -1,0 +1,16 @@
+package com.suggestion.book.domain.book.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class SimilarBookListResponseDto {
+    public Response response;
+    public static class Response {
+        public int resultNum;
+        public List<SimilarBook> docs;
+    }
+}

--- a/src/main/java/com/suggestion/book/domain/book/service/BookService.java
+++ b/src/main/java/com/suggestion/book/domain/book/service/BookService.java
@@ -1,0 +1,30 @@
+package com.suggestion.book.domain.book.service;
+
+import com.suggestion.book.domain.book.dto.SimilarBookListResponseDto;
+import com.suggestion.book.global.config.properties.ApiProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class BookService {
+    private final WebClient data4libraryWebClientApi;
+    private final ApiProperties apiProperties;
+    public static final String URI = "/recommandList";
+
+    public Mono<SimilarBookListResponseDto> getSimilarBookList(String isbn, String type) {
+        return data4libraryWebClientApi
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(URI)
+                        .queryParam("authKey", apiProperties.getNaru().getAuthKey())
+                        .queryParam("isbn13", isbn)
+                        .queryParam("type", type)
+                        .queryParam("format", "json")
+                        .build())
+                .retrieve()
+                .bodyToMono(SimilarBookListResponseDto.class);
+    }
+}


### PR DESCRIPTION
### 이슈

- #26 

### 주요 변경 사항
1. 도서관정보나루 api를 통하여 비슷한 도서 추천 기능을 구현하였습니다.
2. 마니아 or 다독자 를 위한 추천도서 조회기능이 가능합니다.

<br>

closes #26 



