### PR TITLE
사용자 닉네임 변경 기능 구현

### DIFF
--- a/src/main/java/com/suggestion/book/domain/member/controller/MemberController.java
+++ b/src/main/java/com/suggestion/book/domain/member/controller/MemberController.java
@@ -1,11 +1,15 @@
 package com.suggestion.book.domain.member.controller;
 
 import com.suggestion.book.domain.member.dto.MemberResponseDto;
+import com.suggestion.book.domain.member.dto.NicknameRequestDto;
 import com.suggestion.book.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -16,5 +20,12 @@ public class MemberController {
     @GetMapping(path = "/member")
     public MemberResponseDto getMember(@AuthenticationPrincipal User principal) {
         return memberService.getMember(principal.getUsername());
+    }
+
+    @PostMapping(path = "/member/nickname")
+    public ResponseEntity<String> updateNickname(@AuthenticationPrincipal User principal,
+                                              @RequestBody NicknameRequestDto nicknameRequestDto) {
+        memberService.updateNickname(nicknameRequestDto, principal.getUsername());
+        return ResponseEntity.ok("닉네임 변경 성공");
     }
 }

--- a/src/main/java/com/suggestion/book/domain/member/dto/NicknameRequestDto.java
+++ b/src/main/java/com/suggestion/book/domain/member/dto/NicknameRequestDto.java
@@ -1,0 +1,10 @@
+package com.suggestion.book.domain.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NicknameRequestDto {
+    public String nickname;
+}

--- a/src/main/java/com/suggestion/book/domain/member/entity/Member.java
+++ b/src/main/java/com/suggestion/book/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.suggestion.book.domain.member.entity;
 
+import com.suggestion.book.domain.member.dto.NicknameRequestDto;
 import com.suggestion.book.domain.model.ProviderType;
 import com.suggestion.book.domain.model.RoleType;
 import com.suggestion.book.domain.model.TimestampEntity;
@@ -54,5 +55,9 @@ public class Member extends TimestampEntity {
         this.profileImageUrl = profileImageUrl != null ? profileImageUrl : "";
         this.providerType = providerType;
         this.roleType = roleType;
+    }
+
+    public void updateNickname(NicknameRequestDto nicknameRequestDto) {
+        this.nickname = nicknameRequestDto.getNickname();
     }
 }

--- a/src/main/java/com/suggestion/book/domain/member/service/MemberService.java
+++ b/src/main/java/com/suggestion/book/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.suggestion.book.domain.member.service;
 
 import com.suggestion.book.domain.member.dto.MemberResponseDto;
+import com.suggestion.book.domain.member.dto.NicknameRequestDto;
 import com.suggestion.book.domain.member.entity.Member;
 import com.suggestion.book.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,5 +15,10 @@ public class MemberService {
     public MemberResponseDto getMember(String memberId) {
         Member member = memberRepository.findByMemberId(memberId);
         return MemberResponseDto.from(member);
+    }
+
+    public void updateNickname(NicknameRequestDto nicknameRequestDto, String memberId) {
+        Member member = memberRepository.findByMemberId(memberId);
+        member.updateNickname(nicknameRequestDto);
     }
 }


### PR DESCRIPTION
### 이슈

- #40

### 주요 변경 사항
1. 사용자의 초기 닉네임은 이름이지만 사용자가 원하면 변경이 가능하도록 구현하였습니다.

<br>

closes #40 



