### PR TITLE
댓글 조회 시 폐치 조인을 통한 JPA 성능 개선

### DIFF
--- a/src/main/java/com/suggestion/book/domain/community/repository/CommentRepository.java
+++ b/src/main/java/com/suggestion/book/domain/community/repository/CommentRepository.java
@@ -5,6 +5,7 @@ import com.suggestion.book.domain.community.entity.Review;
 import com.suggestion.book.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +17,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("delete from Comment c where c.review.no =:no ")
     void deleteByReview(Long no);
 
+    @EntityGraph(attributePaths = "member")
     Page<Comment> findAllByReview(Pageable pageable, Review review);
     Page<Comment> findAllByMember(Pageable pageable, Member member);
 }


### PR DESCRIPTION
### 이슈

- #48 

### 주요 변경 사항
1.  댓글 조회 시  fetch join 하여 쿼리 성능을 상승 시켰습니다.

<br>

closes #48 



