### PR TITLE
JWT 액세스 토큰 유효기간 30분에서 24시간으로 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,7 +76,7 @@ jwt:
 app:
   auth:
     tokenSecret: ENC(dSsEBRpI+EpYojJI6aREoYZchmg+8wnqbtM1hlM5yQu/hOsOJuUyXVSqel/pVbF8g86BIG10dlS4dZtRj57hiMITZpZTj+0eXAxdXA5wj7A=)
-    tokenExpiry: 1800000
+    tokenExpiry: 86400000 #24 hour
     refreshTokenExpiry: 604800000
   oauth2:
     authorizedRedirectUris:


### PR DESCRIPTION
### 이슈

- #58

### 주요 변경 사항
1. JWT 액세스 토큰 유효기간 30분에서 24시간으로 수정하였습니다.

<br>

closes #58 



