### PR TITLE
chatGPT API를 이용하여 코드리뷰 등록

### DIFF
--- a/.github/workflows/codeReview.yml
+++ b/.github/workflows/codeReview.yml
@@ -1,0 +1,19 @@
+name: Code Review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anc95/ChatGPT-CodeReview@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          LANGUAGE: Korean


### PR DESCRIPTION
### 이슈

- #68 

### 주요 변경 사항
1.  open API 키를 받아 chatGPT API와 연결하였습니다.
2. 이제 풀리퀘스트를 할때마다 chatGPT가 코드리뷰를 해줍니다.

<br>

[깃허브 소스](https://github.com/anc95/ChatGPT-CodeReview)

closes #68 
