### PR TITLE
리엑트 배포시 도메인 CORS 전부 허용

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,7 +63,7 @@ spring:
 
 
 cors:
-  allowed-origins: 'http://localhost:3000'
+  allowed-origins: '*'
   allowed-methods: GET,POST,PUT,DELETE,OPTIONS
   allowed-headers: '*'
   max-age: 3600


### PR DESCRIPTION
### 이슈

- #80

### 주요 변경 사항
1. 배포시 CORS 도메인을 전부 허용합니다.
2. 추후 보안을 위해 변경을 해야합니다.

<br>

closes #80 



