### PR TITLE
allowed-origins 도메인 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,7 +63,7 @@ spring:
 
 
 cors:
-  allowed-origins: 'http://localhost:3000,https://www.look-book,site'
+  allowed-origins: 'http://localhost:3000,https://www.look-book.site,https:localhost:3000'
   allowed-methods: GET,POST,PUT,DELETE,OPTIONS
   allowed-headers: '*'
   max-age: 3600

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,7 +63,7 @@ spring:
 
 
 cors:
-  allowed-origins: '*'
+  allowed-origins: 'http://localhost:3000,https://www.look-book,site'
   allowed-methods: GET,POST,PUT,DELETE,OPTIONS
   allowed-headers: '*'
   max-age: 3600


### PR DESCRIPTION
### 이슈

- #82

### 주요 변경 사항
1. allowed-origins 도메인 수정
2. allowCredentials가 ture 경우 "*"(모든 도메인 허용) 사용불기

<br>

#### 참고
[CorsConfiguration 공식문서](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOrigins(java.util.List))

closes #82 



